### PR TITLE
find: fix compatibility with GNU getopt(3)

### DIFF
--- a/src.freebsd/findutils/find/main.c
+++ b/src.freebsd/findutils/find/main.c
@@ -90,7 +90,7 @@ main(int argc, char *argv[])
 	p = start = argv;
 	Hflag = Lflag = 0;
 	ftsoptions = FTS_NOSTAT | FTS_PHYSICAL;
-	while ((ch = getopt(argc, argv, "EHLPXdf:sx")) != -1)
+	while ((ch = getopt(argc, argv, "+EHLPXdf:sx")) != -1)
 		switch (ch) {
 		case 'E':
 			regexp_flags |= REG_EXTENDED;


### PR DESCRIPTION
By default, GNU getopt(3) will continue parsing options after the first nonoption. This behavior is incompatible with this find(1) implementation, causing parts of the expression to be parsed as (invalid) options:

```
$ find . -name foo
find: invalid option -- 'n'
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
```

The behavior can be disabled by prefixing the option string with a `+` character. Other applets, such as flock or mcookie do it already so it would be cool to do this here too to make find(1) compatible with glibc.