### PR TITLE
env: Fix compatibility with glibc getopt

### DIFF
--- a/src.freebsd/coreutils/env/env.c
+++ b/src.freebsd/coreutils/env/env.c
@@ -85,7 +85,7 @@ main(int argc, char **argv)
 	pw = NULL;
 	want_clear = 0;
 	term = '\n';
-	while ((ch = getopt(argc, argv, "0C:iP:S:u:v")) != -1)
+	while ((ch = getopt(argc, argv, "+0C:iP:S:u:v")) != -1)
 		switch(ch) {
 		case '-':
 		case 'i':


### PR DESCRIPTION
Fixes:

```
$ echo asdf | src.freebsd/coreutils/env/env FOO=bar sed -n 's/asdf/qwer/'
src.freebsd/coreutils/env/env: invalid option -- 'n'
usage: env [-0iv] [-C workdir] [-L|-U user[/class]] [-P utilpath] [-S string]
           [-u name] [name=value ...] [utility [argument ...]]
```