### PR TITLE
readlink(1): fix mistake in man page

### DIFF
--- a/src.custom/realpath/readlink.1
+++ b/src.custom/realpath/readlink.1
@@ -22,7 +22,7 @@ The options are as follows:
 Instead of reading link target, canonicalize
 .Ar path
 similarly to the
-.Nm readlink
+.Nm realpath
 utility. All components must exist.
 .It Fl m, -canonicalize-missing
 Like above, but no components must exist.


### PR DESCRIPTION
The man page says for the `-f` option:

```
             Instead of reading link target, canonicalize path similarly to
             the readlink utility. All components must exist.
```

It should be realpath -- this **is** the readlink utility.