### PR TITLE
nl: fix oversized stack allocation with NL_TEXTMAX under glibc

### DIFF
--- a/src.freebsd/coreutils/nl/nl.c
+++ b/src.freebsd/coreutils/nl/nl.c
@@ -361,7 +361,7 @@ static void
 parse_numbering(const char *argstr, int section)
 {
 	int error;
-	char errorbuf[NL_TEXTMAX];
+	char errorbuf[256];
 
 	switch (argstr[0]) {
 	case 'a':


### PR DESCRIPTION
nl.c declares this stack buffer to hold regex errors.
```c
 char errorbuf[NL_TEXTMAX]; 
``` 
glibc defines it as INT_MAX, so it tries to allocate 2gb. On BSD systems this number is 255.
Setting it as 256 matches bsd and is enough for any regex message.
```c
 char errorbuf[256];
``` 