### PR TITLE
nc(1): fix CFI violations

### DIFF
--- a/src.freebsd/netcat/atomicio.c
+++ b/src.freebsd/netcat/atomicio.c
@@ -65,3 +65,11 @@ atomicio(ssize_t (*f) (int, void *, size_t), int fd, void *_s, size_t n)
 	}
 	return (pos);
 }
+
+/*
+ * Write wrapper to make clang CFI happy
+ */
+ssize_t vwrite(int f, void *s, size_t n)
+{
+	return write(f, s, n);
+}

--- a/src.freebsd/netcat/atomicio.h
+++ b/src.freebsd/netcat/atomicio.h
@@ -34,6 +34,9 @@
  */
 size_t	atomicio(ssize_t (*)(int, void *, size_t), int, void *, size_t);
 
-#define vwrite (ssize_t (*)(int, void *, size_t))write
+/*
+ * Write wrapper to make clang CFI happy
+ */
+ssize_t vwrite(int, void *, size_t);
 
 #endif /* _ATOMICIO_H */


### PR DESCRIPTION
The netcat implementation relies on calling `read`/`write` through a function pointer, however the two function signatures are not identical, so clang CFI throws whenever `write` gets called indirectly (even though the function signatures *are* compatible).
https://github.com/chimera-linux/chimerautils/blob/66db3db163cf273feaba1db7d9eebb8f369bdf21/src.freebsd/netcat/atomicio.c#L35-L51

The list of possible functions is already known, so this fix just hardcodes the options to stop CFI from throwing a fit.

The problematic code paths only occur if you use the proxy functionality (`-x`/`-X`) or in one specific other case using telnet.

This is important as the distributed `nc` binary in the Chimera Linux repos has clang CFI enabled, and so the proxy functionality *cannot* be used with the officially distributed binaries.