### PR TITLE
stty: glibc compatibility

### DIFF
--- a/src.freebsd/coreutils/stty/util.c
+++ b/src.freebsd/coreutils/stty/util.c
@@ -68,9 +68,14 @@ static const speed_t baudvals[] = {
 };
 
 int get_baud(speed_t s) {
+#ifdef __GLIBC__
+	/* in glibc the speed_t constants are the baud rate itself */
+	return (int)s;
+#else
 	if (s & CBAUDEX)
 		s = (s & ~CBAUDEX) + 15;
 	return baudlist[s];
+#endif
 }
 
 speed_t get_speed(unsigned long b) {


### PR DESCRIPTION
On glibc [the baud constants are the baud rate itself](https://sourceware.org/git/?p=glibc.git;a=blob;f=bits/termios-baud.h;h=a43619466bd8285ab7e8ab6b512a9dbeadc1913a;hb=HEAD). In contrast to musl where they are an index. Prior to this change `stty -a` would segfault when trying to do `baudlist[38400]`.

Is `gen-patch.sh` the script to run to update `patches/src.freebsd.patch`? I ran it and there were a bunch of changes unrelated to my change.